### PR TITLE
Refactor ffmpeg and exiftool installation in workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -159,7 +159,7 @@ jobs:
               BIN_ARGS="\
                 --add-binary bin/ffmpeg:bin \
                 --add-binary bin/exiftool:bin \
-                --add-data bin/exiftool_files:bin/exiftool_files"
+                --add-data bin/exiftool_lib:bin/exiftool_lib"
             fi
 
             pyinstaller $COMMON_ARGS $BIN_ARGS script.py


### PR DESCRIPTION
#28 Install exiftool from source to avoid linux/mac errors when trying to call dependency