### PR TITLE
fix: off-by-one fix for retry attempts, fixes #49

### DIFF
--- a/src/downloaders.py
+++ b/src/downloaders.py
@@ -285,7 +285,7 @@ def memory_download(
         max_retries = 3
         retry_delay = 2  # seconds
 
-        for attempt in range(0, max_retries):
+        for attempt in range(1, max_retries + 1):
             try:
                 print(
                     f"\rDownloading {idx + 1}/{total_files}: {name}...",
@@ -360,8 +360,8 @@ def memory_download(
             except requests.exceptions.Timeout:
                 if attempt < max_retries:
                     print(
-                        f"\nMemory {idx}: Timeout, retrying "
-                        f"({attempt}/{max_retries})...\n"
+                        f"\nMemory {idx}: Timeout on attempt "
+                        f"({attempt}/{max_retries}), retrying...\n"
                     )
                     time.sleep(retry_delay)
                 else:
@@ -374,8 +374,8 @@ def memory_download(
             except requests.exceptions.ConnectionError:
                 if attempt < max_retries:
                     print(
-                        f"\nMemory {idx}: Connection error, retrying "
-                        f"({attempt}/{max_retries})...\n"
+                        f"\nMemory {idx}: Connection error on attempt "
+                        f"({attempt}/{max_retries}), retrying...\n"
                     )
                     time.sleep(retry_delay)
                 else:
@@ -394,8 +394,8 @@ def memory_download(
                 if 500 <= status < 600:
                     if attempt < max_retries:
                         print(
-                            f"\nMemory {idx}: Server error {status}, "
-                            f"retry attempt {attempt}/{max_retries}"
+                            f"\nMemory {idx}: Server error {status} on attempt "
+                            f"({attempt}/{max_retries}), retrying...\n"
                         )
                         time.sleep(retry_delay)
                         continue


### PR DESCRIPTION
As the code sits, when encountering an error, we see something like:

```
Downloading 543/8792: 2023-12-10-193143...
Memory 542: Server error 500, retry attempt 0/3
Downloading 698/8792: 2023-07-30-143659...
Memory 697: File already exists, skipping
```

The logline is a little confusing, on the first error I think it should read more like "server error 500 on attempt 1/3, retrying...".

Also upon reading the attempt code, it ranges from 0 to 2, so the loop actually never executes on attempt "3", so none of the failure code tracking actually would run.

Without modifying too much code, I just shifted the loop by one to cover all the failure tracking logic :D

Fixes #49 

Thank you so much for sharing this tool out! Super helpful!!